### PR TITLE
Feature/enhance and complement article

### DIFF
--- a/app/Article.php
+++ b/app/Article.php
@@ -79,6 +79,13 @@ class Article implements Arrayable
         return $this->frontmatter;
     }
 
+    public function setFrontmatter(array $assoc): array
+    {
+        $this->frontmatter = $assoc;
+
+        return $this->frontmatter;
+    }
+
     /**
      * @param string $path
      *

--- a/app/Article.php
+++ b/app/Article.php
@@ -5,6 +5,7 @@ namespace App;
 use App\Traits\TracksAttributeChanges;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Facades\Storage;
+use Symfony\Component\Yaml\Exception\ParseException;
 
 class Article implements Arrayable
 {
@@ -82,6 +83,7 @@ class Article implements Arrayable
      * @param string $path
      *
      * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     * @throws ParseException                                         when the Yaml is syntactically wrong
      *
      * @return Article
      */

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "fzaninotto/faker": "^1.4",
         "mockery/mockery": "^1.0",
         "nunomaduro/collision": "^2.0",
-        "phpunit/phpunit": "^7.0"
+        "phpunit/phpunit": "^7.0",
+        "timacdonald/log-fake": "^1.0"
     },
     "config": {
         "optimize-autoloader": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "677b23a3871cf45d0c55630510eeddf5",
+    "content-hash": "f995ea31a8c157617040dda06c6866fc",
     "packages": [
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -5368,6 +5368,55 @@
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "time": "2017-04-07T12:08:54+00:00"
+        },
+        {
+            "name": "timacdonald/log-fake",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/timacdonald/log-fake.git",
+                "reference": "46bf3d3e1d121d6ea085f05f3ff400b8e411e00a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/timacdonald/log-fake/zipball/46bf3d3e1d121d6ea085f05f3ff400b8e411e00a",
+                "reference": "46bf3d3e1d121d6ea085f05f3ff400b8e411e00a",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/config": "~5.6",
+                "illuminate/container": "~5.6",
+                "illuminate/support": "~5.6",
+                "php": "^7.1.3",
+                "phpunit/phpunit": "^7.0",
+                "psr/log": "^1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "TiMacDonald\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Tim MacDonald",
+                    "email": "hello@timacdonald.me",
+                    "homepage": "https://timacdonald.me"
+                }
+            ],
+            "description": "A drop in fake logger for testing with the Laravel framework.",
+            "keywords": [
+                "fake",
+                "laravel",
+                "log",
+                "logger",
+                "testing"
+            ],
+            "time": "2018-10-06T03:36:12+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/config/logging.php
+++ b/config/logging.php
@@ -44,6 +44,12 @@ return [
             'level' => 'debug',
         ],
 
+        'testing' => [
+            'driver' => 'single',
+            'path' => storage_path('logs/testing.log'),
+            'level' => 'debug',
+        ],
+
         'daily' => [
             'driver' => 'daily',
             'path' => storage_path('logs/laravel.log'),

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -32,5 +32,6 @@
         <env name="DB_CONNECTION" value="sqlite" />
         <env name="DB_DATABASE" value="database/database.sqlite" />
         <env name="FILESYSTEM_DRIVER" value="testing" />
+        <env name="LOG_CHANNEL" value="testing" />
     </php>
 </phpunit>

--- a/tests/Feature/ArticleTest.php
+++ b/tests/Feature/ArticleTest.php
@@ -70,6 +70,7 @@ class ArticleTest extends TestCase
 
     /**
      * @test
+     * @markdown
      *
      * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      */
@@ -102,6 +103,7 @@ class ArticleTest extends TestCase
 
     /**
      * @test
+     * @group markdown
      *
      * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      */
@@ -279,5 +281,41 @@ class ArticleTest extends TestCase
         return [
             ["wrong_indentation:\n\t\t\tkey: value"],
         ];
+    }
+
+    /**
+     * @test
+     * @group markdown
+     *
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     * @throws ParseException
+     */
+    public function it_can_handle_empty_markdown()
+    {
+        $path = fake_hierarchical_slug();
+        // no markdown
+        Storage::put($path, "---\ntitle: title---\n");
+        $article = new Article(['path' => $path]);
+        $article->load();
+        $this->assertEquals('', $article->getMarkdown());
+    }
+
+    /**
+     * @test
+     * @group markdown
+     * @group yaml
+     *
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     * @throws ParseException
+     */
+    public function it_can_handle_both_empty_fronmatter_and_empty_markdown()
+    {
+        $path = fake_hierarchical_slug();
+        // no markdown
+        Storage::put($path, "---\n---\n");
+        $article = new Article(['path' => $path]);
+        $article->load();
+        $this->assertEquals('', $article->getMarkdown());
+        $this->assertEquals([], $article->getFrontmatter());
     }
 }

--- a/tests/Feature/ArticleTest.php
+++ b/tests/Feature/ArticleTest.php
@@ -308,7 +308,7 @@ class ArticleTest extends TestCase
      * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
      * @throws ParseException
      */
-    public function it_can_handle_both_empty_fronmatter_and_empty_markdown()
+    public function it_can_handle_both_empty_frontmatter_and_empty_markdown()
     {
         $path = fake_hierarchical_slug();
         // no markdown

--- a/tests/Feature/ArticleTest.php
+++ b/tests/Feature/ArticleTest.php
@@ -4,8 +4,12 @@ namespace Tests\Feature;
 
 use App\Article;
 use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
+use Symfony\Component\Yaml\Exception\ParseException;
+use Symfony\Component\Yaml\Yaml;
 use Tests\TestCase;
+use TiMacDonald\Log\LogFake;
 
 /**
  * @group article
@@ -136,5 +140,144 @@ class ArticleTest extends TestCase
         Storage::assertExists($article->getPath());
         $article->delete();
         Storage::assertMissing($article->getPath());
+    }
+
+    /**
+     * @test
+     * @group yaml
+     * @dataProvider validYamlProvider
+     *
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     * @throws ParseException
+     */
+    public function it_loads_valid_yaml($validYaml, $expectedResult)
+    {
+        $path = fake_hierarchical_slug();
+        Storage::put($path, "---\n{$validYaml}---\n# Heading");
+        $article = new Article(['path' => $path]);
+        $article->load();
+        $this->assertEquals($expectedResult, $article->getFrontmatter());
+        $this->assertEquals('# Heading', $article->getMarkdown());
+    }
+
+    public function validYamlProvider()
+    {
+        return [
+            // data set #0
+            [
+                // validYaml
+                "title: title\n",
+
+                // expectedResult
+                [
+                    'title' => 'title',
+                ],
+            ],
+            // data set #1
+            [
+                "images:\n".
+                "   - { ref: my-image, caption: 'my caption' }\n".
+                "   - { ref: another-image, caption: 'another caption' }\n",
+
+                [
+                    'images' => [
+                        [
+                            'ref' => 'my-image',
+                            'caption' => 'my caption',
+                        ],
+                        [
+                            'ref' => 'another-image',
+                            'caption' => 'another caption',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @group yaml
+     *
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     * @throws ParseException
+     */
+    public function it_can_handle_empty_frontmatter()
+    {
+        $path = fake_hierarchical_slug();
+        Storage::put($path, "---\n---\n# Heading");
+        $article = new Article(['path' => $path]);
+        $article->load();
+        $this->assertEquals([], $article->getFrontmatter());
+        $this->assertEquals('# Heading', $article->getMarkdown());
+    }
+
+    /**
+     * @test
+     * @group yaml
+     * @dataProvider unexpectedYamlProvider
+     *
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     * @throws ParseException
+     */
+    public function it_handles_unexpected_yaml_format_gracefully_and_logs_it($unexpectedYaml)
+    {
+        // make sure we can assert logging
+        Log::swap(new LogFake());
+
+        // given we have an article with unexpected yaml format in frontmatter
+        $path = fake_hierarchical_slug();
+        $markdown = '# Heading';
+        Storage::put($path, "---\n{$unexpectedYaml}---\n{$markdown}");
+        $article = new Article(['path' => $path]);
+        // when we load that article
+        $article->load();
+
+        // then we expect the unexpected yaml to be ignored and an empty array to be returned instead
+        $this->assertEquals([], $article->getFrontmatter());
+        // and we expect this to be logged as a warning
+        Log::assertLogged('warning');
+        // and to have access to the markdown
+        $this->assertEquals($markdown, $article->getMarkdown());
+    }
+
+    /**
+     * Provides us with a set of unexpected yaml frontmatter, that will usually not result in an assoc array.
+     *
+     * @return array
+     */
+    public function unexpectedYamlProvider(): array
+    {
+        return [
+            // no space between key and value
+            ["title:asdf\n"],
+            // no key / value
+            ["nokeyvalue\n"],
+        ];
+    }
+
+    /**
+     * @test
+     * @group yaml
+     * @dataProvider yamlSyntaxErrorProvider
+     *
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
+     */
+    public function it_throws_an_exception_when_frontmatter_is_syntactically_wrong($syntacticallyWrongYaml)
+    {
+        $path = fake_hierarchical_slug();
+        $markdown = '# Heading';
+        Storage::put($path, "---\n{$syntacticallyWrongYaml}---\n{$markdown}");
+        $article = new Article(['path' => $path]);
+        // we expect a ParseException here (see @expectedException)
+        $article->load();
+    }
+
+    public function yamlSyntaxErrorProvider(): array
+    {
+        return [
+            ["wrong_indentation:\n\t\t\tkey: value"],
+        ];
     }
 }


### PR DESCRIPTION
Bitte `composer install` ausführen.

* Frontmatter / Yaml Edgecases werden nun ordentlich behandelt.
* Test für leeres Markdown hinzugefügt
* Frontmatter / Yaml kann nun nicht nur aktualisiert werden (ausgelassene Properties wurden dabei ja beibehalten), sondern auch fix gesetzt werden, was das Löschen von Properties ermöglicht.

[edit]
Außerdem:

* Unerwartetes Yaml-Format in Frontmatter (das kein Array erzeugt) wird ignoriert (leeres Array wird zurückgegeben) aber als warning geloggt.
* Logging während Testing erfolgt in eigene Datei, um die echten Log-Dateien nicht zu verrauschen
* Neue Abhängigkeit `timacdonald/log-fake` erlaubt uns in Tests assertions für Logging durchzuführen
